### PR TITLE
Nicer config syntax

### DIFF
--- a/lib/tco.rb
+++ b/lib/tco.rb
@@ -88,6 +88,13 @@ module Tco
   def self.config
     @config
   end
+  
+  def self.configure
+    c = config
+    yield(c)
+    reconfigure(c)
+    c
+  end
 
   def self.reconfigure(config)
     @config = config


### PR DESCRIPTION
This change will allow this syntax for configuration.

``` ruby
Tco.configure do |conf|
  conf.names['purple'] = '#622e90'
end
```
