### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tco - terminal colours made simple
 
 [![Gem Version](https://badge.fury.io/rb/tco.png)](http://badge.fury.io/rb/tco)
+[![Inline docs](http://inch-pages.github.io/github/pazdera/tco.png)](http://inch-pages.github.io/github/pazdera/tco)
 
 The purpose of the **tco** gem is to make colouring in the terminal as
 convenient and as simple as possible. It provides a library for your Ruby gems


### PR DESCRIPTION
Hi Radek,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-pages.github.io/github/pazdera/tco.png)](http://inch-pages.github.io/github/pazdera/tco)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-pages.github.io/github/pazdera/tco/

Inch Pages is still a young project, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
