### PR TITLE
fixed deprecated code

### DIFF
--- a/lib/tco/config.rb
+++ b/lib/tco/config.rb
@@ -57,7 +57,7 @@ module Tco
 
       locations.each do |conf_file|
         conf_file = File.expand_path conf_file
-        next unless File.exists? conf_file
+        next unless File.exist? conf_file
         load conf_file
       end
     end


### PR DESCRIPTION
File.exists? has been deprecated since Ruby 2.2 and it has been fully removed after Ruby 3.x