### PR TITLE
Fixing Ruby 3.2 removed method File::exists

### DIFF
--- a/lib/tco/config.rb
+++ b/lib/tco/config.rb
@@ -57,7 +57,7 @@ module Tco
 
       locations.each do |conf_file|
         conf_file = File.expand_path conf_file
-        next unless File.exists? conf_file
+        next unless File.exist? conf_file
         load conf_file
       end
     end


### PR DESCRIPTION
The method `exists` is removed since Ruby 3.2 ; The method `exist?` is ok on Ruby 2.0 and more recent.